### PR TITLE
check that all strings are localized

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "prepublish": "bower install --config.analytics=false; grunt aloha --verbose",
     "upgrade": "npm update; bower update --config.analytics=false; grunt aloha --verbose",
     "test": "grunt test --verbose",
+    "posttest": "node ./script/check-templates-for-non-i18n-text.js",
     "dist": "grunt dist --verbose"
   },
   "repository": {
@@ -18,6 +19,7 @@
   },
   "devDependencies": {
     "csso": "~1.3.11",
+    "glob": "^7.1.1",
     "grunt-coffeelint": "~0.0.13",
     "grunt-contrib-clean": "~0.6.0",
     "grunt-contrib-connect": "^1.0.2",
@@ -33,6 +35,8 @@
     "grunt-nginx": "~0.2.2",
     "grunt-string-replace": "~1.2.0",
     "grunt-targethtml": "~0.2.6",
+    "jquery": "^3.1.1",
+    "jsdom": "^9.9.1",
     "less": "~1.7.5",
     "rjs-build-analysis": "~0.0.3"
   },

--- a/script/check-templates-for-non-i18n-text.js
+++ b/script/check-templates-for-non-i18n-text.js
@@ -1,0 +1,52 @@
+const fs = require('fs')
+const glob = require('glob')
+const jsdom = require('jsdom')
+const jquery = require('jquery')
+
+glob('./src/**/*.html', (err, filenames) => {
+  filenames.forEach((filename) => {
+
+    // Skip certain files
+    if (/fake-exercises/.test(filename) || /tos-template/.test(filename)) {
+      return
+    }
+
+    const contents = fs.readFileSync(filename)
+    const document = jsdom.jsdom(`<html><body>${contents}</body></html>`)
+    const $ = jquery(document.defaultView)
+
+    // Remove any text inside elements that are marked with a data-l10n-id
+    // TODO: Verify all data-l10n-id values are in the JSON (warn if not in the polish ones)
+    $('[data-l10n-id]').contents().remove()
+
+    // Handlebars has `{{ logic-here }}` brackets as text nodes so remove them
+    $('*').each((index, el) => {
+      const text = el.textContent
+      // HACK a crude way to remove handlebars
+      if (/\{\{/.test(text)) {
+        el.textContent = ''
+      }
+    })
+
+    // Remove the <noscript> element
+    $('noscript,script,title,style').remove()
+
+    // Remove the annoying "X" for closing the dialog
+    $('[aria-hidden="true"]').remove()
+
+    // ./src/scripts/pages/about/contact/contact-template.html has the "Contact us" address
+    // maybe exclude the entire file?
+    $('.contact > p').remove()
+
+    const remainingDocumentText = $('body').text().trim() // document.documentElement.innerText
+    if (remainingDocumentText.length !== 0) {
+      console.error(`ERROR: Non-internationalized text found in ${filename}`);
+      console.log('-------------------------- HTML: --------------------------');
+      console.log(document.documentElement.innerHTML);
+      console.log('-------------------------- REMAINING TEXT: --------------------------');
+      console.log(remainingDocumentText);
+      console.log('----------------------------------------------------');
+      process.exit(1)
+    }
+  })
+})


### PR DESCRIPTION
This parses all of the HTML files (handlebars templates) checks to see if any text nodes exist after doing the following:

1. removing the text nodes inside elements with `[data-l10n-id]`
1. remove `<script>` tags

I will try to circle back later (but no guarantees) to add better messages and maybe check that the `[data-l10n-id]` values exist

/cc @pandafulmanda and @RoyEJohnson for thoughts on having this type of test in webview

and @ludekarts for review 😄 